### PR TITLE
Feature/segment

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,3 +2,4 @@
 *.nf.test linguist-language=nextflow
 modules/nf-core/** linguist-generated
 subworkflows/nf-core/** linguist-generated
+modules/local/lungmask/unet_r231-d5d2fc3d.pth filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ testing/
 testing*
 *.pyc
 null/
+.git/COMMIT_EDITMSG

--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ work/
 data/
 results/
 .DS_Store
+test/
 testing/
 testing*
 *.pyc

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,9 +5,18 @@ repos:
       - id: prettier
         additional_dependencies:
           - prettier@3.2.5
+        # 添加以下配置来指定要格式化的文件类型
+        types: [file] # 必须的基础类型
+        types_or: [css, javascript, jsx, ts, tsx, json, yaml, markdown] # 指定要格式化的文件类型
 
   - repo: https://github.com/editorconfig-checker/editorconfig-checker.python
     rev: "3.0.3"
     hooks:
       - id: editorconfig-checker
         alias: ec
+
+  - repo: https://github.com/commitizen-tools/commitizen
+    rev: v3.13.0
+    hooks:
+      - id: commitizen
+        stages: [commit-msg]

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -1,32 +1,51 @@
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Config file for defining DSL2 per module options and publishing paths
+    这是一个配置文件，用于定义 DSL2 模块（即 Nextflow 的流程模块）的选项和输出文件的发布路径。
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-    Available keys to override module options:
-        ext.args   = Additional arguments appended to command in module.
-        ext.args2  = Second set of arguments appended to command in module (multi-tool modules).
-        ext.args3  = Third set of arguments appended to command in module (multi-tool modules).
-        ext.prefix = File name prefix for output files.
+    你可以通过下面这些关键字自定义模块的行为：
+        ext.args   = 额外的参数，会附加到模块运行的命令后面。
+        ext.args2  = 第二组额外参数，用于支持需要多个工具参数的模块。
+        ext.args3  = 第三组额外参数，也是为了支持复杂的多工具模块。
+        ext.prefix = 为输出文件设置文件名前缀。
 ----------------------------------------------------------------------------------------
 */
 
-process {
+process { // 这个 `process` 块定义了任务的行为，包括文件输出的位置和模块参数
 
+    // 设置任务输出文件的发布规则
     publishDir = [
-        path: { "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}" },
-        mode: params.publish_dir_mode,
-        saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+        path: { // 定义输出文件的目标路径
+            // 输出路径的逻辑是：在参数 `params.outdir` 指定的目录下，
+            // 根据当前任务的名称（`task.process`）动态生成子目录。
+            // 比如，如果任务名称是 "MODULE:FASTQC"，生成的子目录会是 "fastqc"。
+            "${params.outdir}/${task.process.tokenize(':')[-1].tokenize('_')[0].toLowerCase()}"
+        },
+        mode: params.publish_dir_mode, // 决定如何发布文件（如：复制、软链接或硬链接），从参数中读取
+        saveAs: { filename -> // 定义是否发布某些文件
+            // 如果文件名是 "versions.yml"，则不发布（返回 `null`）；否则正常发布文件
+            filename.equals('versions.yml') ? null : filename
+        }
     ]
 
-    withName: FASTQC {
-        ext.args = '--quiet'
+    // 定义特定模块的自定义行为，这里是针对模块名称的规则
+    withName: FASTQC { // 如果模块名称是 "FASTQC"
+        ext.args = '--quiet' // 添加一个额外参数 `--quiet`，让模块静默运行
     }
-    withName: 'MULTIQC' {
-        ext.args   = { params.multiqc_title ? "--title \"$params.multiqc_title\"" : '' }
-        publishDir = [
-            path: { "${params.outdir}/multiqc" },
-            mode: params.publish_dir_mode,
-            saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
+
+    withName: 'MULTIQC' { // 如果模块名称是 "MULTIQC"
+        ext.args = { // 定义额外参数
+            // 如果用户通过参数 `params.multiqc_title` 提供了标题，就加上 `--title "标题"` 参数；
+            // 如果没有提供标题，就不加额外参数。
+            params.multiqc_title ? "--title \"$params.multiqc_title\"" : ''
+        }
+        publishDir = [ // 对 MULTIQC 模块单独定义发布规则
+            path: { // 这个模块的输出文件会放到 `params.outdir/multiqc` 目录下
+                "${params.outdir}/multiqc"
+            },
+            mode: params.publish_dir_mode, // 同样使用全局参数 `params.publish_dir_mode` 决定发布方式
+            saveAs: { filename -> // 和全局规则一致：不发布 "versions.yml"，其他文件正常发布
+                filename.equals('versions.yml') ? null : filename
+            }
         ]
     }
 

--- a/main_test.nf
+++ b/main_test.nf
@@ -1,5 +1,35 @@
-include {PLASTIMATCH_CONVERT} from './modules/local/plastimatch' //地址前必须加./
+// 引入外部模块：从本地的 'plastimatch' 模块中导入 PLASTIMATCH_CONVERT 转换工具
+include { PLASTIMATCH_CONVERT } from './modules/local/plastimatch/main.nf'
 
+// 数据通道创建和处理阶段
+samples_ch = Channel
+    // 从指定路径读取 CSV 文件（通过 params.input 参数定义）
+    .fromPath(params.input)
+    // 读取的 CSV 文件格式如下：
+    // sample,path
+    // SAMPLE_1,/path/to/data/SAMPLE_1/CT
+    // SAMPLE_2,/path/to/data/SAMPLE_2/CT
+    // SAMPLE_3,/path/to/data/SAMPLE_3/CT
+
+
+    // 将 CSV 文件按行拆分，识别表头
+    .splitCsv(header: true)
+
+    // 对每一行记录进行数据转换和元数据构建
+    .map { record ->
+        // 创建元数据对象，使用 sample 列作为唯一标识符
+        def meta = [id: record.sample]
+
+        // 将路径转换为文件对象
+        def input_dir = file(record.path)
+
+        // 返回元组：(元数据, 输入目录)
+        tuple(meta, input_dir)
+    }
+
+// 定义主工作流程
 workflow {
-     PLASTIMATCH_CONVERT( "/work/run/projects/fanxi/nextflow/biofree-radiomics/modules/local/plastimatch/tests/data/input/R01-001")
+    // 将处理好的数据通道直接传递给 PLASTIMATCH_CONVERT 模块进行转换
+    samples_ch
+        | PLASTIMATCH_CONVERT
 }

--- a/main_test.nf
+++ b/main_test.nf
@@ -1,0 +1,5 @@
+include {PLASTIMATCH_CONVERT} from './modules/local/plastimatch' //地址前必须加./
+
+workflow {
+     PLASTIMATCH_CONVERT( "/work/run/projects/fanxi/nextflow/biofree-radiomics/modules/local/plastimatch/tests/data/input/R01-001")
+}

--- a/main_test.nf
+++ b/main_test.nf
@@ -1,27 +1,31 @@
 // 引入外部模块：从本地的 'plastimatch' 模块中导入 PLASTIMATCH_CONVERT 转换工具
 include { PLASTIMATCH_CONVERT } from './modules/local/plastimatch/main.nf'
+include { LUNG_SEGMENTATION } from './modules/local/lungmask/main.nf'
+include { RESAMPLE } from './modules/local/resample'
 
 // 数据通道创建和处理阶段
 samples_ch = Channel
     // 从指定路径读取 CSV 文件（通过 params.input 参数定义）
     .fromPath(params.input)
-    // 读取的 CSV 文件格式如下：
+    .ifEmpty { exit 1, "未找到输入 CSV 文件" }
+    // 将 CSV 文件按行拆分，识别表头
     // sample,path
     // SAMPLE_1,/path/to/data/SAMPLE_1/CT
     // SAMPLE_2,/path/to/data/SAMPLE_2/CT
     // SAMPLE_3,/path/to/data/SAMPLE_3/CT
-
-
-    // 将 CSV 文件按行拆分，识别表头
     .splitCsv(header: true)
 
+
     // 对每一行记录进行数据转换和元数据构建
-    .map { record ->
+    .map { row ->
         // 创建元数据对象，使用 sample 列作为唯一标识符
-        def meta = [id: record.sample]
+        def meta = [
+            id: row.sample,
+            patient_id: row.patient_id ?: row.sample
+        ]
 
         // 将路径转换为文件对象
-        def input_dir = file(record.path)
+        def input_dir = file(row.path)
 
         // 返回元组：(元数据, 输入目录)
         tuple(meta, input_dir)
@@ -29,7 +33,11 @@ samples_ch = Channel
 
 // 定义主工作流程
 workflow {
-    // 将处理好的数据通道直接传递给 PLASTIMATCH_CONVERT 模块进行转换
-    samples_ch
-        | PLASTIMATCH_CONVERT
+    // 转换数据通道中的每个样本
+    PLASTIMATCH_CONVERT(samples_ch)
+
+    RESAMPLE(PLASTIMATCH_CONVERT.out.converted_image)
+
+    // 进行肺部分割
+    LUNG_SEGMENTATION(PLASTIMATCH_CONVERT.out.converted_image).view()
 }

--- a/modules/local/lungmask/environment.yml
+++ b/modules/local/lungmask/environment.yml
@@ -1,0 +1,17 @@
+channels:
+  - defaults
+  - conda-forge
+  - bioconda
+dependencies:
+  - python=3.11
+  - pip:
+      - lungmask==0.2.20
+      - fill_voids
+      - more-itertools
+      - numpy
+      - pydicom
+      - scikit-image
+      - scipy
+      - SimpleITK
+      - torch
+      - tqdm

--- a/modules/local/lungmask/main.nf
+++ b/modules/local/lungmask/main.nf
@@ -1,0 +1,35 @@
+process LUNG_SEGMENTATION {
+    // 1. 进程标识和资源管理
+    tag "${meta.id}"
+    label 'process_medium'
+
+    // 2. 环境和容器管理
+    // conda "${moduleDir}/environment.yml"
+
+    // // 使用 Singularity 且不直接拉取 Docker 镜像时，需要使用 docker:// 前缀
+    container "${
+        workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'docker://august777/radiomics-lungmask:1.0.1' :
+        'august777/radiomics-lungmask:1.0.1'
+    }"
+    publishDir "${params.outdir}/lung_segment" , mode: 'copy'
+
+    input:
+    tuple val(meta), path(image_file)
+
+    output:
+    tuple val(meta), path("*_lung_seg.nii.gz"), emit: lung_seg_nii
+
+    script:
+    """
+    lungmask "${image_file}"  "${meta.id}_lung_seg.nii.gz" --modelpath "${moduleDir}/unet_r231-d5d2fc3d.pth"
+    """
+
+    // 8. 桩测试
+    stub:
+    def output_filename = "${meta.id}_lung_seg.nii.gz"
+    """
+    # 生成占位符文件
+    touch ${output_filename}
+    """
+}

--- a/modules/local/lungmask/resources/usr/bin/example.py
+++ b/modules/local/lungmask/resources/usr/bin/example.py
@@ -1,0 +1,1 @@
+import fire

--- a/modules/local/lungmask/unet_r231-d5d2fc3d.pth
+++ b/modules/local/lungmask/unet_r231-d5d2fc3d.pth
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:d5d2fc3df432115933491f115b283e94d1f5c841c0e82f6e7bd2d65d3ccde69f
+size 124340403

--- a/modules/local/nnunet/main.nf
+++ b/modules/local/nnunet/main.nf
@@ -1,0 +1,29 @@
+process NNUNET_SEGMENTATION {
+    input:
+    path input_dir
+    path output_dir
+
+    output:
+    path "${output_dir}"
+
+    script:
+    """
+    docker run --rm \\
+      --gpus all \\
+      -v \$(pwd)/plastimatch:/app/data/input \\
+      -v ${output_dir}:/app/data/output \\
+      --name radiomics_task \\
+      radiomics_gpu:2.0 \\
+      -i /app/data/input \\
+      -o /app/data/output \\
+      -t Task006_Lung \\
+      -m 3d_fullres
+    """
+}
+
+workflow {
+    input_dir = "${launchDir}/results/plastimatch"
+    output_dir = "${launchDir}/results/output"
+
+    radiomics_task(input_dir, output_dir)
+}

--- a/modules/local/plastimatch/Dockerfile
+++ b/modules/local/plastimatch/Dockerfile
@@ -1,6 +1,8 @@
 FROM ubuntu
 
 # 切换apt源为中国的镜像源
-RUN apt-get update \
-    && apt-get install -y plastimatch procps 
-# 准备bash
+RUN sed -i 's/deb.debian.org/mirrors.aliyun.com/g' /etc/apt/sources.list \
+    && apt-get update \
+    && apt-get install -y plastimatch procps \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*

--- a/modules/local/plastimatch/Dockerfile
+++ b/modules/local/plastimatch/Dockerfile
@@ -1,0 +1,6 @@
+FROM ubuntu
+
+# 切换apt源为中国的镜像源
+RUN apt-get update \
+    && apt-get install -y plastimatch procps 
+# 准备bash

--- a/modules/local/plastimatch/main.nf
+++ b/modules/local/plastimatch/main.nf
@@ -1,15 +1,85 @@
 process PLASTIMATCH_CONVERT {
-    tag "plastimatch"
+    // 1. 进程标识和资源管理
+    tag "${meta.id}"
+    label 'process_medium'
+
+    // 2. 环境和容器管理
+    // conda "${moduleDir}/environment.yml" plastimatch 暂时无法使用conda安装
+    container "${
+        workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'docker://lfabriko/plastimatch:latest' :
+        'lfabriko/plastimatch:latest'
+    }"
+
+    // 3. 进程输入定义
     input:
-        path input_dir
+    // 元数据 + 输入目录
+    tuple val(meta), path(input_dir)
+
+    // 4. 进程输出定义
     output:
-        path "*.nii.gz"
-    publishDir "./output", mode: 'copy'
+    // 转换后的图像文件
+    tuple val(meta), path("${meta.id}_0000.nii.gz"), emit: converted_image
+
+    // 日志和版本输出
+    // TODO: 日志和版本不知道如何使用
+    path("plastimatch_convert.log")          , emit: log
+    path("versions.yml")                     , emit: versions
+
+    // 5. 执行条件控制
+    when:
+    task.ext.when == null || task.ext.when
+
+    // 6. 错误处理策略
+    errorStrategy 'retry'
+    maxRetries 2
+
+    // 7. 主执行脚本
     script:
+    // 处理可选参数
+    def additional_args = task.ext.args ?: ''
+    def output_filename = "${meta.id}_0000.nii.gz"
+
     """
-    plastimatch convert --input "${input_dir}" --output-img "xx.nii.gz"
+    # 开始转换日志
+    echo "开始Plastimatch转换: ${meta.id}" > plastimatch_convert.log
+
+    # 执行Plastimatch转换
+    plastimatch convert \\
+        --input "${input_dir}" \\
+        --output-img "${output_filename}" \\
+        ${additional_args} \\
+        2>> plastimatch_convert.log
+
+    # 验证转换是否成功
+    if [ ! -f "${output_filename}" ]; then
+        echo "转换失败：未生成输出文件" >&2
+        exit 1
+    fi
+
+    # 记录Plastimatch版本
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        plastimatch: \$(plastimatch | grep -oP '(?<=version ).*')
+    END_VERSIONS
+
+    # TODO: 日志最终只保留最后的，需要改进
+    # 完成日志
+    echo "Plastimatch转换完成: ${meta.id}" >> plastimatch_convert.log
     """
+
+    // 8. 桩测试
+    stub:
+    def output_filename = "${meta.id}_0000.nii.gz"
+    """
+    # 生成占位符文件
+    touch ${output_filename}
+    touch plastimatch_convert.log
+
+    cat <<-END_VERSIONS > versions.yml
+    "${task.process}":
+        plastimatch: "stub-version"
+    END_VERSIONS
+    """
+
 }
-
-//路径过深导致失灵，换成容器试试
-

--- a/modules/local/plastimatch/main.nf
+++ b/modules/local/plastimatch/main.nf
@@ -17,12 +17,14 @@ process PLASTIMATCH_CONVERT {
     tuple val(meta), path(input_dir)
 
     // 4. 进程输出定义
+    // conf/modules.config 中定义了输出文件的发布路径
     output:
     // 转换后的图像文件
     tuple val(meta), path("${meta.id}_0000.nii.gz"), emit: converted_image
 
     // 日志和版本输出
     // TODO: 日志和版本不知道如何使用
+    // NOTE: conf/modules.config 中声明了 versions.yml 不发布
     path("plastimatch_convert.log")          , emit: log
     path("versions.yml")                     , emit: versions
 

--- a/modules/local/plastimatch/main.nf
+++ b/modules/local/plastimatch/main.nf
@@ -5,10 +5,12 @@ process PLASTIMATCH_CONVERT {
 
     // 2. 环境和容器管理
     // conda "${moduleDir}/environment.yml" plastimatch 暂时无法使用conda安装
+
+    // 使用 Singularity 且不直接拉取 Docker 镜像时，需要使用 docker:// 前缀
     container "${
         workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
-        'docker://lfabriko/plastimatch:latest' :
-        'lfabriko/plastimatch:latest'
+        'docker://august777/radiomics-plastimatch:1.4.7' :
+        'august777/radiomics-plastimatch:1.4.7'
     }"
 
     // 3. 进程输入定义

--- a/modules/local/plastimatch/main.nf
+++ b/modules/local/plastimatch/main.nf
@@ -1,0 +1,15 @@
+process PLASTIMATCH_CONVERT {
+    tag "plastimatch"
+    input:
+        path input_dir
+    output:
+        path "*.nii.gz"
+    publishDir "./output", mode: 'copy'
+    script:
+    """
+    plastimatch convert --input "${input_dir}" --output-img "xx.nii.gz"
+    """
+}
+
+//路径过深导致失灵，换成容器试试
+

--- a/modules/local/resample/main.nf
+++ b/modules/local/resample/main.nf
@@ -1,0 +1,36 @@
+process RESAMPLE {
+    // 1. 进程标识和资源管理
+    tag "${meta.id}"
+    label 'process_medium'
+
+    // 2. 环境和容器管理
+    // conda "${moduleDir}/environment.yml"
+    conda "fire SimpleITK"
+
+    // // 使用 Singularity 且不直接拉取 Docker 镜像时，需要使用 docker:// 前缀
+    container "${
+        workflow.containerEngine == 'singularity' && !task.ext.singularity_pull_docker_container ?
+        'community.wave.seqera.io/library/fire_simpleitk:b83798408e975594' :
+        'community.wave.seqera.io/library/fire_simpleitk:b83798408e975594'
+    }"
+    publishDir "${params.outdir}/resample" , mode: 'copy'
+
+    input:
+    tuple val(meta), path(image_file)
+
+    output:
+    tuple val(meta), path("*_resample.nii.gz"), emit: resample_nii
+    // TODO: 后续可暴露new_spacing参数
+    script:
+    """
+    resample.py "${image_file}"  "${meta.id}_resample.nii.gz"
+    """
+
+    // 8. 桩测试
+    stub:
+    def output_filename = "${meta.id}_resample.nii.gz"
+    """
+    # 生成占位符文件
+    touch ${output_filename}
+    """
+}

--- a/modules/local/resample/resources/usr/bin/resample.py
+++ b/modules/local/resample/resources/usr/bin/resample.py
@@ -1,0 +1,68 @@
+#! /usr/bin/env python3
+""" 对NIFTI图像进行重采样 """
+
+import fire
+import SimpleITK as sitk
+
+
+def resample_nifti_image(
+    image_dir, output_filename=None, new_spacing=(0.4, 0.4, 0.4), save=True
+):
+    """
+    对NIFTI图像进行重采样
+
+    参数:
+    - image_dir: 输入图像路径
+    - new_spacing: 新的像素间距，默认为(0.4, 0.4, 0.4)
+    - output_filename: 输出文件名
+    - save: 是否保存重采样图像
+
+    返回:
+    - 重采样后的图像
+    """
+    # 读取图像并转换为浮点类型
+    sitk_img = sitk.ReadImage(str(image_dir), sitk.sitkFloat32)
+
+    # 获取原始间距
+    original_spacing = sitk_img.GetSpacing()
+
+    # 创建重采样滤波器
+    resample_filter = sitk.ResampleImageFilter()
+
+    # 设置重采样参数
+    resample_filter.SetDefaultPixelValue(0)
+    resample_filter.SetOutputSpacing(new_spacing)
+
+    # 动态计算新的图像大小
+    resample_filter.SetSize(
+        [
+            int(round(osz * ospc / nspc))
+            for osz, ospc, nspc in zip(
+                sitk_img.GetSize(), original_spacing, new_spacing
+            )
+        ]
+    )
+
+    # 保留原始图像的方向和原点
+    resample_filter.SetOutputDirection(sitk_img.GetDirection())
+    resample_filter.SetOutputOrigin(sitk_img.GetOrigin())
+
+    # 设置线性插值
+    resample_filter.SetInterpolator(sitk.sitkLinear)
+
+    # 执行重采样
+    resampled_img = resample_filter.Execute(sitk_img)
+
+    # 保存图像（如果需要）
+    if save and output_filename is not None:
+        sitk.WriteImage(resampled_img, output_filename, useCompression=True)
+
+    # 打印间距信息（可选）
+    print("Original Spacing:", sitk_img.GetSpacing())
+    print("Resampled Spacing:", resampled_img.GetSpacing())
+
+    return resampled_img
+
+
+if __name__ == "__main__":
+    fire.Fire(resample_nifti_image)

--- a/nextflow.config
+++ b/nextflow.config
@@ -147,7 +147,7 @@ profiles {
         singularity.ociAutoPull = true
         wave.enabled            = true
         wave.freeze             = false //dev
-        wave.strategy           = 'dockerfile,conda,container'
+        wave.strategy           = 'container,dockerfile,conda'
         docker.enabled          = true //关键,实现容器dockerfile
 
     }
@@ -173,10 +173,10 @@ includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${pa
 // Set default registry for Apptainer, Docker, Podman, Charliecloud and Singularity independent of -profile
 // Will not be used unless Apptainer / Docker / Podman / Charliecloud / Singularity are enabled
 // Set to your registry if you have a mirror of containers
-apptainer.registry    = 'quay.io'
-docker.registry       = 'quay.io'
+apptainer.registry    = 'docker.rainbond.cc'
+docker.registry       = 'docker.rainbond.cc'
 podman.registry       = 'quay.io'
-singularity.registry  = 'quay.io'
+singularity.registry  = 'docker.rainbond.cc'
 charliecloud.registry = 'quay.io'
 
 // Load igenomes.config if required

--- a/nextflow.config
+++ b/nextflow.config
@@ -146,7 +146,7 @@ profiles {
         apptainer.ociAutoPull   = true
         singularity.ociAutoPull = true
         wave.enabled            = true
-        wave.freeze             = true
+        wave.freeze             = false //dev
         wave.strategy           = 'dockerfile,conda,container'
         docker.enabled          = true //关键,实现容器dockerfile
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -147,7 +147,9 @@ profiles {
         singularity.ociAutoPull = true
         wave.enabled            = true
         wave.freeze             = true
-        wave.strategy           = 'conda,container'
+        wave.strategy           = 'dockerfile,conda,container'
+        docker.enabled          = true //关键,实现容器dockerfile
+
     }
     gitpod {
         executor.name           = 'local'
@@ -157,6 +159,9 @@ profiles {
     test      { includeConfig 'conf/test.config'      }
     test_full { includeConfig 'conf/test_full.config' }
 }
+
+// 允许使用模块二进制文件，在module/resouces/usr/bin
+nextflow.enable.moduleBinaries = true
 
 // Load nf-core custom profiles from different Institutions
 includeConfig !System.getenv('NXF_OFFLINE') && params.custom_config_base ? "${params.custom_config_base}/nfcore_custom.config" : "/dev/null"
@@ -188,14 +193,13 @@ env {
     JULIA_DEPOT_PATH = "/usr/local/share/julia"
 }
 
-// Set bash options
+// 设置 Bash 选项
 process.shell = """\
 bash
 
-set -e # Exit if a tool returns a non-zero status/exit code
-set -u # Treat unset variables and parameters as an error
-set -o pipefail # Returns the status of the last command to exit with a non-zero status or zero if all successfully execute
-set -C # No clobber - prevent output redirection from overwriting files.
+set -e # 如果工具返回非零状态/退出代码，则退出
+set -u # 将未设置的变量和参数视为错误
+set -o pipefail # 返回最后一个命令的状态，该命令以非零状态退出；如果所有命令都成功执行，则返回零
 """
 
 // Disable process selector warnings by default. Use debug profile to enable warnings.

--- a/nextflow.config
+++ b/nextflow.config
@@ -26,7 +26,7 @@ params {
     multiqc_methods_description = null
 
     // Boilerplate options
-    outdir                       = null
+    outdir                       = "results"
     publish_dir_mode             = 'copy'
     email                        = null
     email_on_fail                = null
@@ -246,7 +246,7 @@ validation {
         command = "nextflow run $manifest.name -profile <docker/singularity/.../institute> --input samplesheet.csv --outdir <OUTDIR>"
         fullParameter = "help_full"
         showHiddenParameter = "show_hidden"
-        
+
     }
 }
 

--- a/nfcore_template.yaml
+++ b/nfcore_template.yaml
@@ -1,0 +1,54 @@
+name: radiomics
+description: radiomics-flow is a pipeline for radiomics analysis
+author: fanxi
+org: biofree
+
+prefix: biofree
+skip:
+  - github
+  - ci
+  # - github_badges
+  - igenomes
+  - nf_core_configs
+template:
+  author: fanxi
+  description: radiomics-flow is a pipeline for radiomics analysis
+  force: true
+  is_nfcore: false
+  name: radiomics-flow
+  org: biofree
+  outdir: .
+  skip_features:
+    - github
+    - ci
+    - igenomes
+    - nf_core_configs
+    - code_linters
+    - citations
+    - gitpod
+    - codespaces
+    # - multiqc
+    - fastqc
+    - modules
+    - changelog
+    - nf_schema
+    - license
+    - email
+    - adaptivecard
+    - slackreport
+    - documentation
+    - test_config
+    - seqera_platform
+  version: 1.0.0dev
+
+# 许可证信息
+license:
+  type: MIT
+  year: 2024
+  organization: biofree
+
+# 联系方式
+contact:
+  email: fanxingfu3344@gmail.com
+  github: https://github.com/biofree
+  website: https://www.biofree.com

--- a/script/generate_sample_csv.sh
+++ b/script/generate_sample_csv.sh
@@ -1,0 +1,1 @@
+find $(pwd)/data/sorted -type d -name 'R01*' | awk -F/ '{print $NF","$0"/CT"}' > sample.csv


### PR DESCRIPTION
<!--
# biofree/radiomics pull request

Many thanks for contributing to biofree/radiomics!

Please fill in the appropriate checklist below (delete whatever is not relevant).
These are the most common things requested on pull requests (PRs).

Remember that PRs should be made against the dev branch, unless you're preparing a pipeline release.
This pull request includes several changes to the Nextflow pipeline configuration and modules, focusing on adding new processes, updating configurations, and improving the overall workflow. The most important changes include adding new processes for lung segmentation and resampling, updating the configuration files for better container management, and adding support for new file types in the pre-commit configuration.

### New Processes and Modules:
* [`modules/local/lungmask/main.nf`](diffhunk://#diff-1d9a9bf7a4d4f53d5710181aa6226478d2ea284ea3157aad0cec17118ef35a35R1-R35): Added a new process `LUNG_SEGMENTATION` for lung segmentation using the lungmask tool with Singularity and Docker container support.
* [`modules/local/resample/main.nf`](diffhunk://#diff-af09b486f8c2dc691b9a0552cc59d35f636fe943daf0322b2bc983ae6bfd1f96R1-R36): Added a new process `RESAMPLE` for resampling images using SimpleITK with Conda and Singularity container support.
* [`modules/local/plastimatch/main.nf`](diffhunk://#diff-d7150a9599a73b922be3edf5c60fab3b0987d5cb98c9bd24e435d9a9834bd106R1-R89): Added a new process `PLASTIMATCH_CONVERT` for converting images using Plastimatch with Docker container support.

### Configuration Updates:
* [`nextflow.config`](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL29-R29): Updated default output directory, container registry settings, and enabled module binaries. Added Dockerfile support in the `wave.strategy` and updated the `profiles` section to improve container management. [[1]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL29-R29) [[2]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL149-R152) [[3]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaR163-R165) [[4]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL171-R179) [[5]](diffhunk://#diff-ce7465a8e67b3b9c95696db1146ca7e6328f075e08a3d64062b87aa8608fc4eaL191-R202)
* [`.pre-commit-config.yaml`](diffhunk://#diff-63a9c44a44acf85fea213a857769990937107cf072831e1a26808cfde9d096b9R8-R22): Added new hooks for `commitizen` and specified file types for `prettier` formatting.

### File Additions:
* [`modules/local/lungmask/unet_r231-d5d2fc3d.pth`](diffhunk://#diff-a8f800649a951cb4caf579aa831c4d36eafdded52df7c74e9348edce513927beR1-R3): Added a new model file for lung segmentation using lungmask.
* [`modules/local/lungmask/environment.yml`](diffhunk://#diff-88dbd454757e919bf67da84176644ffa99e3b0a0d4fdf636c9ed3bfd001f8b87R1-R17): Added a new environment file for lungmask dependencies.

### Workflow Enhancements:
* [`main_test.nf`](diffhunk://#diff-590a02a852137084036cb5f931245c062a4b71617838f13dfdbbd3f32630c529R1-R43): Included new processes `PLASTIMATCH_CONVERT`, `LUNG_SEGMENTATION`, and `RESAMPLE` in the main workflow for better data processing and analysis.

### Miscellaneous:
* [`script/generate_sample_csv.sh`](diffhunk://#diff-3f81b74338b2285492175eaf2b37d443f8fbe338886dcdbe06a8905651e8af8fR1): Added a script to generate a sample CSV file for data processing.
Learn more about contributing: [CONTRIBUTING.md](https://github.com/biofree/radiomics/tree/master/.github/CONTRIBUTING.md)
-->

## PR checklist

- [ ] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/biofree/radiomics/tree/master/.github/CONTRIBUTING.md)
- [ ] Make sure your code lints (`nf-core pipelines lint`).
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [x] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
